### PR TITLE
fix: Pin Python version to `3.11`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
        - name: Set up Python
          uses: actions/setup-python@v4
          with:
-           python-version: '3.x'
+           python-version: '3.11'
        - name: Install dependencies
          run: |
            pip install -r requirements.txt

--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -14,9 +14,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: '3.11'
       - name: Install dependencies
         run: |
+          pip install --upgrade pip
           pip install -r requirements.txt
       - name: Generate code
         run: |


### PR DESCRIPTION
Latest Python version doesn't work with the Arrow version we're using (we're using the latest Arrow version but a new version should be released soon)